### PR TITLE
"Success Stories" link in navbar fix

### DIFF
--- a/src/components/navbar/DesktopNavbar.jsx
+++ b/src/components/navbar/DesktopNavbar.jsx
@@ -12,7 +12,7 @@ function DesktopNavbar() {
         <div className="flex gap-16 lg:gap-28">
             <Link to="/about">About</Link>
             <Link to="/services">Services</Link>
-            <Link to="/#success-stories">Success Stories</Link>
+            <Link to="/#success-stories" className="whitespace-nowrap">Success Stories</Link>
             <Link to="/faq">FAQ</Link>
         </div>
 


### PR DESCRIPTION
- The "Success Stories" link now stays on one line in the tablet view instead of two lines